### PR TITLE
Scripts for Exporting Labs / Instructor Materials

### DIFF
--- a/export_instructor.sh
+++ b/export_instructor.sh
@@ -13,5 +13,5 @@ else
     find . -type f -name "*[Nn]otes.tex" | cpio -pdv $1
     cp SIAM-GH-book.cls $1
     cp command.tex $1
-
+    cp *.pdf $1
 fi

--- a/export_instructor.sh
+++ b/export_instructor.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copy all instructor materials to a specified directory.
+
+if ["$#" -ne 1 ]; then
+    echo -e "Provide the name of the target directory"
+else
+    # Solutions files (.py and .ipynb)
+    find . -type f -name "solutions.py" | cpio -pdv $1
+    find . -type f -name "solutions.ipynb" | cpio -pdv $1
+    # Test drivers TODO: "*test_driver*.py"
+    find . -type f -name "testDriver.py" | cpio -pdv $1
+    # Instructor Notes
+    find . -type f -name "*[Nn]otes.tex" | cpio -pdv $1
+    cp SIAM-GH-book.cls $1
+    cp command.tex $1
+
+fi

--- a/export_labs.sh
+++ b/export_labs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copy all files required to compile the tex files to a specified directory.
+
+if ["$#" -ne 1 ]; then
+    echo -e "Provide the name of the target directory"
+else
+    # Tex files
+    find . -type f -name "*.tex" | cpio -pdv $1
+    # Pictures and figures
+    find . -type f -name "*.png" | cpio -pdv $1
+    find . -type f -name "*.pdf" | cpio -pdv $1
+    find . -type f -name "*.jpg" | cpio -pdv $1
+    find . -type f -name "*.jpeg" | cpio -pdv $1
+    # Support files
+    cp SIAM-GH-book.cls $1
+    find . -type f -depth 1 -name "*travis*" | cpio -pdv $1
+
+    # Files included with \lstinputlisting[style=fromfile]{}
+    mkdir $1/Appendices/f2py/flaplace
+    mkdir $1/Appendices/f2py/fssor
+    mkdir $1/Appendices/f2py/ftridiag
+
+    cp Appendices/f2py/flaplace/flaplace.f90 $1/Appendices/f2py/flaplace
+    cp Appendices/f2py/fssor/* $1/Appendices/f2py/fssor
+    cp Appendices/f2py/ftridiag/* $1/Appendices/f2py/ftridiag
+    cp Appendices/mpltables/*.py $1/Appendices/mpltables
+    cp Vol1A/ImageSegmentation/getNeighbors.py $1/Vol1A/ImageSegmentation/getNeighbors.py
+    cp Vol3B/WebTech1-InternetProtocol/tcp_server.py $1/Vol3B/WebTech1-InternetProtocol/tcp_server.py
+    cp Vol3B/WebTech1-InternetProtocol/tcp_client.py $1/Vol3B/WebTech1-InternetProtocol/tcp_client.py
+    cp Vol3B/WebTech2-Serialization/contacts.xml $1/Vol3B/WebTech2-Serialization/contacts.xml
+    cp Vol4A/ShootingMethod/secant_method.py $1/Vol4A/ShootingMethod/secant_method.py
+
+    # Remove extra files
+    rm -rf $1/Orphans
+    rm $1/InstructorNotes.tex
+    rm $1/ExtraLabs.tex
+    find $1 -type f -name "Notes.tex" -exec rm {} +
+    if [ -e $1/onelab.tex ]; then
+        rm $1/onelab.tex
+    fi
+fi


### PR DESCRIPTION
This repository has everything in it except for data (tex, figures, specs, solutions, and test drivers). Proposal for moving toward splitting this repository up:
- Make a new public repo called **Labs** that has all tex files and related materials.
- Privatize this repo.
- Make a new private repo called **Instructor-Materials** with all solutions files and test drivers.

In the future, we should make a public repo for _each_ semester of the curriculum (Volume1A, Volume1B, etc.) that students can fork and clone at the beginning of each semester. These should contain spec and auxiliary files, and _maybe_ relevant data files. For now we're using [acme.byu.edu](http://www.acme.byu.edu/?page_id=1172) to distribute specs.


This pull request adds two scripts for
1. exporting all of the lab tex materials to a new directory
2. exporting all of the instructor materials to a new directory

This will facilitate migrating changes from this repository (where we have everything in one place) to **Labs** and **InstructorMaterials** so we can develop in one place, but distribute correctly.