### PR TITLE
Test Driver Minor Updates (Jan 2017)

### DIFF
--- a/Introduction/Exceptions/test_driver.py
+++ b/Introduction/Exceptions/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: Exceptions and File I/O. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver
 
 import signal

--- a/Introduction/Exceptions/test_driver.py
+++ b/Introduction/Exceptions/test_driver.py
@@ -77,7 +77,7 @@ class TestDriver(BaseTestDriver):
                     return self._grade(1, "Poor error message")
                 except Exception as e:
                     self.feedback += message
-                    self.feedback +="(got {} instead)".format(self._errType(e))
+                    self.feedback +="(got {} instead)".format(self._objType(e))
                     self.feedback += "\n\tError message: {}".format(e)
                 else:
                     self.feedback += message
@@ -142,7 +142,7 @@ class TestDriver(BaseTestDriver):
         except Exception as e:
             self.feedback += "\nContentFilter.__init__() failed to raise a "
             self.feedback += "TypeError (got {} instead)".format(
-                                                            self._errType(e))
+                                                            self._objType(e))
         else:
             self.feedback += "\nFailed to raise a TypeError"
 
@@ -171,7 +171,7 @@ class TestDriver(BaseTestDriver):
                 return 1
             except Exception as e:
                 self.feedback += message
-                self.feedback +="\n\t(got {} instead)".format(self._errType(e))
+                self.feedback +="\n\t(got {} instead)".format(self._objType(e))
             else:
                 self.feedback += message
             return 0

--- a/Introduction/NumpyIntro/test_driver.py
+++ b/Introduction/NumpyIntro/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: Intro to NumPy. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from solutions import *

--- a/Introduction/OOP/test_driver.py
+++ b/Introduction/OOP/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: Object Oriented Programming. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from math import sqrt

--- a/Introduction/PlottingIntro/test_driver.py
+++ b/Introduction/PlottingIntro/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: Intro to Matplotlib. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _autoclose
 
 

--- a/Introduction/PythonIntro/test_driver.py
+++ b/Introduction/PythonIntro/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: Intro to Python. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from numpy.random import randint

--- a/Introduction/StandardLibrary/test_driver.py
+++ b/Introduction/StandardLibrary/test_driver.py
@@ -2,7 +2,7 @@
 """Introductory Labs: The Standard Library. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from subprocess import call

--- a/Vol1A/ImageSegmentation/test_driver.py
+++ b/Vol1A/ImageSegmentation/test_driver.py
@@ -2,7 +2,7 @@
 """Vol1A: Image Segmentation. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import numpy as np

--- a/Vol1A/IterativeSolvers/test_driver.py
+++ b/Vol1A/IterativeSolvers/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1A: Iterative Solvers. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol1A/LinearSystems/test_driver.py
+++ b/Vol1A/LinearSystems/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1A: Linear Systems. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol1A/LinearTransformations/test_driver.py
+++ b/Vol1A/LinearTransformations/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1A: Linear Transformations. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 from solutions import *

--- a/Vol1A/QR1_Decomposition/test_driver.py
+++ b/Vol1A/QR1_Decomposition/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1A: QR 1 (Decomposition). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import numpy as np

--- a/Vol1A/QR2_LeastSquares/test_driver.py
+++ b/Vol1A/QR2_LeastSquares/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1A: QR 2 (Least Squares and Computing Eigenvalues). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol1A/SVD/test_driver.py
+++ b/Vol1A/SVD/test_driver.py
@@ -1,7 +1,7 @@
 # test_driver.py
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol1B/Differentiation/test_driver.py
+++ b/Vol1B/Differentiation/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1B: Numerical Differentiation. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import numpy as np

--- a/Vol1B/MonteCarlo1_Integration/test_driver.py
+++ b/Vol1B/MonteCarlo1_Integration/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1B: Monte Carlo 1 (Integration). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol1B/MonteCarlo2_Sampling/test_driver.py
+++ b/Vol1B/MonteCarlo2_Sampling/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 1B: Monte Carlo 2 (Importance Sampling). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver #, _timeout, _autoclose
 
 from solutions import *

--- a/Vol2A/BFS_KBacon/test_driver.py
+++ b/Vol2A/BFS_KBacon/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Breadth-First Search (Kevin Bacon). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from solutions import *

--- a/Vol2A/DataStructures1_LinkedLists/test_driver.py
+++ b/Vol2A/DataStructures1_LinkedLists/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Data Structures 1 (Linked Lists). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 from os import remove as rm

--- a/Vol2A/DataStructures1_LinkedLists/test_driver.py
+++ b/Vol2A/DataStructures1_LinkedLists/test_driver.py
@@ -96,7 +96,7 @@ class TestDriver(BaseTestDriver):
                 return 1
             except Exception as e:
                 self.feedback += "\nNode.__init__() failed (expected TypeError"
-                self.feedback += ", (got {} instead)".format(self._errType(e))
+                self.feedback += ", (got {} instead)".format(self._objType(e))
             return 0
 
         # Test that anyting other than int, long, float, or str are rejected.
@@ -136,7 +136,7 @@ class TestDriver(BaseTestDriver):
                 return 1
             except Exception as e:
                 self.feedback += "\nLinkedList.find(x) failed {} ".format(info)
-                self.feedback += "(expected ValueError, (got {} instead)".format(self._errType(e))
+                self.feedback += "(expected ValueError, (got {} instead)".format(self._objType(e))
             return 0
 
         l1, l2 = self._load_lists(s)
@@ -226,7 +226,7 @@ class TestDriver(BaseTestDriver):
                     p = 0
             except Exception as e:
                 self.feedback += "\n{} while removing {}: {}{}".format(
-                                            self._errType(e), item, e, old)
+                                            self._objType(e), item, e, old)
             finally:
                 return p, solList, stuList
 
@@ -288,7 +288,7 @@ class TestDriver(BaseTestDriver):
                     p = 0
             except Exception as e:
                 self.feedback += "\n{} while inserting {}: {}{}".format(
-                                            self._errType(e), item, e, old)
+                                            self._objType(e), item, e, old)
             finally:
                 return p, solList, stuList
 
@@ -338,7 +338,7 @@ class TestDriver(BaseTestDriver):
             except Exception as e:
                 self.feedback += "\nDeque.{}() not disabled ".format(func)
                 self.feedback += "correctly\n\t(expected NotImplementedError, "
-                self.feedback += "got {} instead)".format(self._errType(e))
+                self.feedback += "got {} instead)".format(self._objType(e))
                 self.feedback += "\n\tError message: {}".format(e)
             return 0
 
@@ -353,7 +353,7 @@ class TestDriver(BaseTestDriver):
                     p = 0
             except Exception as e:
                 self.feedback += "\n{} while {}ing {}: {}{}".format(
-                                        self._errType(e), func, item, e, old)
+                                        self._objType(e), func, item, e, old)
             finally:
                 return p, solDeque, stuDeque
 
@@ -368,7 +368,7 @@ class TestDriver(BaseTestDriver):
                     p = 0
             except Exception as e:
                 self.feedback += "\n{} while {}ing: {}{}".format(
-                                        self._errType(e), func, e, old)
+                                        self._objType(e), func, e, old)
             finally:
                 return p, solDeque, stuDeque
 

--- a/Vol2A/DataStructures2_Trees/test_driver.py
+++ b/Vol2A/DataStructures2_Trees/test_driver.py
@@ -165,7 +165,7 @@ class TestDriver(BaseTestDriver):
                         "BST.remove({}) failed{}".format(value, oldTree))
             except Exception as e:
                 self.feedback += "\n\t{} while removing {}".format(
-                                                    self._errType(e), value)
+                                                    self._objType(e), value)
                 self.feedback += ": {}{}".format(e, oldTree)
                 p = 0
             finally:

--- a/Vol2A/DataStructures2_Trees/test_driver.py
+++ b/Vol2A/DataStructures2_Trees/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Data Structures 2 (Trees). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 from time import time

--- a/Vol2A/DataStructures3_KDT/test_driver.py
+++ b/Vol2A/DataStructures3_KDT/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Data Structures 3 (Nearest Neighbor Search). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import inspect

--- a/Vol2A/GaussianQuadrature/test_driver.py
+++ b/Vol2A/GaussianQuadrature/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Gaussian Quadrature. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _autoclose, _timeout
 
 import numpy as np

--- a/Vol2A/MarkovChains/test_driver.py
+++ b/Vol2A/MarkovChains/test_driver.py
@@ -124,7 +124,7 @@ class TestDriver(BaseTestDriver):
             points += 2
         except Exception as e:
             self.feedback += "\nExpected a ValueError for A =\n{}".format(A)
-            self.feedback += "\n\t(got {} instead)".format(self._errType(e))
+            self.feedback += "\n\t(got {} instead)".format(self._objType(e))
         else:
             self.feedback += "\nValueError not raised for A =\n{}".format(A)
 

--- a/Vol2A/MarkovChains/test_driver.py
+++ b/Vol2A/MarkovChains/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2A: Markov Chains. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import numpy as np

--- a/Vol2B/CVXOPT_Intro/test_driver.py
+++ b/Vol2B/CVXOPT_Intro/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2B: Intro to CVXOPT. Solutions File."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver
 
 # Get problems, NumPy, and CVXOPT

--- a/Vol2B/InteriorPoint1_Linear/test_driver.py
+++ b/Vol2B/InteriorPoint1_Linear/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2B: Interior Point 1. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol2B/InteriorPoint2_Quadratic/test_driver.py
+++ b/Vol2B/InteriorPoint2_Quadratic/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2B: Interior Point 2 (Quadratic Optimization). Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol2B/ScipyOptimize/test_driver.py
+++ b/Vol2B/ScipyOptimize/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2B: Optimization with SciPy. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout, _autoclose
 
 import numpy as np

--- a/Vol2B/Simplex/test_driver.py
+++ b/Vol2B/Simplex/test_driver.py
@@ -2,7 +2,7 @@
 """Volume 2 Lab 16: Simplex. Test Driver."""
 
 import sys
-sys.path.insert(0, "../..")
+sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver, _timeout
 
 import numpy as np

--- a/test_driver_template.py
+++ b/test_driver_template.py
@@ -6,7 +6,7 @@ the corresponding solutions file. See base_test_driver.py for more information.
 """
 
 # import sys
-# sys.path.insert(0, "../..")
+# sys.path.insert(1, "../..")
 from base_test_driver import BaseTestDriver #, _timeout, _autoclose
 
 class TestDriver(BaseTestDriver):


### PR DESCRIPTION
Changed `base_test_driver.py` so that if a `problemX()` method does not return a numerical value, the test driver stops and throws an error (instead of writing a cryptic error message to the student feedback). 

Also changed `sys.path.insert(0, "../..")` to `sys.path.insert(1, "../..")` so that the current directory is always the default search directory.

See #1354 for previous test driver structural edits.